### PR TITLE
handles undefined param in URL by removing

### DIFF
--- a/dist/url-composer.js
+++ b/dist/url-composer.js
@@ -144,7 +144,9 @@ function replaceArgs (path, args) {
 
   if (isArray(args)) {
     args.forEach(function (arg) {
-      if (arg) { path = replaceArg(path, arg); }
+      //if (arg) { 
+        path = replaceArg(path, arg); 
+      //}
     });
   }
 

--- a/dist/url-composer.js
+++ b/dist/url-composer.js
@@ -172,13 +172,20 @@ function replaceArgs (path, args) {
  */
 function replaceArg (path, arg) {
   var hasNamedParam = path.indexOf(':') !== -1;
-  arg = encodeURIComponent(arg);
+  let encodedarg = encodeURIComponent(arg);
 
   if (hasNamedParam) {
-    return path.replace(NAMED_PARAM, arg)
+    if(arg)//if arg is defined
+    {
+       return path.replace(NAMED_PARAM, encodedarg)
+    }
+    else//if not defined
+    {
+      return path.replace(NAMED_PARAM,'').replace(/(\/)/gi,'')
+    }  
   }
 
-  return path.replace(SPLAT_PARAMS, arg)
+  return path.replace(SPLAT_PARAMS, encodedarg)
 }
 
 /**


### PR DESCRIPTION
Fix for issue 10. Handles undefined url param by assigning value (undefined), then dropping it from the path:

```
  const url = require("url-composer");

let uu = url.build({
    host: "https://www.google.com",
    path: "(/:rsc)/:endpoint",
    params: { endpoint: 'param_endpoint' },
    query: { '$filter': 'filter_xyz' },
  });
console.log(uu)
```